### PR TITLE
feat: add per-validation custom error support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rod_derive"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "rod_validation"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "regex",
  "rod_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rod_validation"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["kommade"]
 description = "A lightweight and ergonomic validation library for Rust"
@@ -12,7 +12,7 @@ categories = ["development-tools", "parsing"]
 
 [dependencies]
 regex = { version = "1.11.2", optional = true }
-rod_derive = { path = "./rod_derive", version = "0.2.2" }
+rod_derive = { path = "./rod_derive", version = "0.2.3" }
 
 [features]
 default = ["regex"]

--- a/rod_derive/Cargo.lock
+++ b/rod_derive/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "rod_derive"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/rod_derive/Cargo.toml
+++ b/rod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rod_derive"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["kommade"]
 description = "Procedural macro for the Rod Validation library"

--- a/rod_derive/README.md
+++ b/rod_derive/README.md
@@ -8,7 +8,7 @@ Procedural macro for the Rod Validation library. This crate provides the `#[deri
 
 ## Overview
 
-`rod_derive` is the procedural macro component of the Rod Validation framework. It automatically generates validation implementations for structs and enums based on declarative attributes.
+`rod_derive` is the procedural macro component of the Rod Validation framework. It automatically generates validation implementations for structs and enumerations based on declarative attributes.
 
 **This crate is typically used through the main `rod_validation` crate and not directly.**
 
@@ -18,7 +18,7 @@ Add Rod Validation to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rod_validation = "0.2.0"
+rod_validation = "0.2.2"
 ```
 
 The derive macro is available through the prelude:
@@ -47,6 +47,7 @@ This includes:
 - Compilation guarantees
 - Performance considerations
 - Advanced features
+- Per-validation custom error messages using the `? "message"` syntax
 - Limitations and troubleshooting
 
 ## Dependencies

--- a/rod_derive/src/types/boolean.rs
+++ b/rod_derive/src/types/boolean.rs
@@ -1,5 +1,5 @@
 use proc_macro_error::abort;
-use syn::{parse::Parse, Ident};
+use syn::{parse::Parse, Ident, LitStr};
 use quote::quote;
 
 use super::optional_braced;
@@ -28,6 +28,9 @@ impl Parse for RodBooleanContent {
 
 impl RodBooleanContent {
     pub(crate) fn get_validations(&self, _field_name: &Ident, _wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+        quote! {}
+    }
+    pub(crate) fn get_validations_with_custom_error(&self, _field_name: &Ident, _wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream, _custom_error: &LitStr) -> proc_macro2::TokenStream {
         quote! {}
     }
 }

--- a/rod_derive/src/types/custom.rs
+++ b/rod_derive/src/types/custom.rs
@@ -1,8 +1,8 @@
 use proc_macro_error::abort;
-use syn::parse::Parse;
+use syn::{parse::Parse, LitStr};
 use quote::quote;
 
-use super::optional_braced;
+use super::{optional_braced, user_defined_error};
 
 pub struct CustomContent;
 
@@ -30,6 +30,15 @@ impl CustomContent {
                 for e in errs {
                     #ret;
                 }
+            }
+        }
+    }
+    pub(crate) fn get_validations_with_custom_error(&self, field_name: &syn::Ident, wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream, custom_error: &LitStr) -> proc_macro2::TokenStream {
+        let ret = user_defined_error(wrap_return, custom_error);
+        quote! {
+            let assert = assert_impl_rod_validate(#field_name);
+            if let Err(_errs) = assert {
+                #ret;
             }
         }
     }

--- a/rod_derive/src/types/float.rs
+++ b/rod_derive/src/types/float.rs
@@ -1,9 +1,9 @@
 use proc_macro_error::abort;
-use syn::{parse::Parse, Ident};
+use syn::{parse::Parse, Ident, LitStr};
 use quote::{quote, ToTokens};
 
 
-use super::{optional_braced, LengthOrSize, NumberSign};
+use super::{optional_braced, user_defined_error, LengthOrSize, NumberSign};
 
 enum FloatType {
     Nan,
@@ -50,7 +50,7 @@ impl ToTokens for FloatType {
 /// # Attributes
 /// - `size`: An optional attribute that specifies the a range for the float to be in, or an exact value for the float.
 /// - `sign`: An optional attribute that specifies the sign of the float, see [`NumberSign`][crate::types::NumberSign] enum.
-/// - `type`: An optional attribute that specifies the type of the float, see [`FloatType`][crate::types::float::FloatType] enum.
+/// - `ftype`: An optional attribute that specifies the type of the float, see [`FloatType`][crate::types::float::FloatType] enum.
 /// # Usage
 /// ```
 /// use rod::prelude::*;
@@ -61,7 +61,7 @@ impl ToTokens for FloatType {
 ///         i32 {
 ///             size: 1.0..=10.0, // or size: 6.0
 ///             sign: Positive,
-///             type: Finite,
+///             ftype: Finite,
 ///         }
 ///     )]
 ///     my_float: i32,
@@ -74,12 +74,19 @@ pub struct RodFloatContent {
     size: Option<LengthOrSize>,
     sign: Option<NumberSign>,
     r#type: Option<FloatType>,
+    custom_errors: [Option<LitStr>; 3], // size, sign, type
 }
 
 impl RodFloatContent {
     pub(crate) fn get_validations(&self, field_name: &Ident, wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         let path = field_name.to_string();
-        let size_opt = self.size.as_ref().map(|size| size.validate_float(field_name, wrap_return));
+        let size_opt = self.size.as_ref().map(|size| {
+            if let Some(msg) = self.custom_errors[0].as_ref() {
+                size.validate_float_with_custom_error(field_name, wrap_return, msg)
+            } else {
+                size.validate_float(field_name, wrap_return)
+            }
+        });
         let sign_opt = self.sign.as_ref().map(|sign| {
             let sign_check = match sign {
                 NumberSign::Positive => quote!(#field_name.is_sign_positive()),
@@ -87,9 +94,13 @@ impl RodFloatContent {
                 NumberSign::Nonpositive => quote!(!#field_name.is_sign_positive()),
                 NumberSign::Nonnegative => quote!(!#field_name.is_sign_negative()),
             };
-            let ret = wrap_return(quote! {
-                RodValidateError::Float(FloatValidation::Sign(#path, #field_name.clone().into(), #sign))
-            });
+            let ret = if let Some(msg) = self.custom_errors[1].as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                wrap_return(quote! {
+                    RodValidateError::Float(FloatValidation::Sign(#path, #field_name.clone().into(), #sign))
+                })
+            };
             quote! {
                 if !(#sign_check) {
                     #ret;
@@ -104,9 +115,65 @@ impl RodFloatContent {
                 FloatType::Normal => quote!(#field_name.is_normal()),
                 FloatType::Subnormal => quote!(#field_name.is_subnormal()),
             };
-            let ret = wrap_return(quote! {
-                RodValidateError::Float(FloatValidation::Type(#path, #field_name.clone().into(), #r#type))
-            });
+            let ret = if let Some(msg) = self.custom_errors[2].as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                wrap_return(quote! {
+                    RodValidateError::Float(FloatValidation::Type(#path, #field_name.clone().into(), #r#type))
+                })
+            };
+            quote! {
+                if !(#type_check) {
+                    #ret;
+                }
+            }
+        });
+        quote! {
+            #size_opt
+            #sign_opt
+            #type_opt
+        }
+    }
+
+    pub(crate) fn get_validations_with_custom_error(&self, field_name: &Ident, wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream, custom_error: &LitStr) -> proc_macro2::TokenStream {
+        let size_opt = self.size.as_ref().map(|size| {
+            if let Some(msg) = self.custom_errors[0].as_ref() {
+                size.validate_float_with_custom_error(field_name, wrap_return, msg)
+            } else {
+                size.validate_float_with_custom_error(field_name, wrap_return, custom_error)
+            }
+        });
+        let sign_opt = self.sign.as_ref().map(|sign| {
+            let sign_check = match sign {
+                NumberSign::Positive => quote!(#field_name.is_sign_positive()),
+                NumberSign::Negative => quote!(#field_name.is_sign_negative()),
+                NumberSign::Nonpositive => quote!(!#field_name.is_sign_positive()),
+                NumberSign::Nonnegative => quote!(!#field_name.is_sign_negative()),
+            };
+            let ret = if let Some(msg) = self.custom_errors[1].as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                user_defined_error(wrap_return, custom_error)
+            };
+            quote! {
+                if !(#sign_check) {
+                    #ret;
+                }
+            }
+        });
+        let type_opt = self.r#type.as_ref().map(|r#type| {
+            let type_check = match r#type {
+                FloatType::Nan => quote!(#field_name.is_nan()),
+                FloatType::Finite => quote!(#field_name.is_finite()),
+                FloatType::Infinite => quote!(#field_name.is_infinite()),
+                FloatType::Normal => quote!(#field_name.is_normal()),
+                FloatType::Subnormal => quote!(#field_name.is_subnormal()),
+            };
+            let ret = if let Some(msg) = self.custom_errors[2].as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                user_defined_error(wrap_return, custom_error)
+            };
             quote! {
                 if !(#type_check) {
                     #ret;
@@ -130,11 +197,14 @@ impl Parse for RodFloatContent {
                 size: None,
                 sign: None,
                 r#type: None,
+                custom_errors: [None, None, None],
             })
         };
         let mut size = None;
         let mut sign = None;
         let mut r#type = None;
+        let mut message: Option<LitStr> = None;
+        let mut custom_errors: [Option<LitStr>; 3] = [None, None, None];
         while !inner.is_empty() {
             let lookahead = inner.lookahead1();
             if lookahead.peek(syn::Ident) {
@@ -143,14 +213,23 @@ impl Parse for RodFloatContent {
                     check_already_used_attr!(size, ident.span());
                     inner.parse::<syn::Token![:]>()?;
                     size = Some(inner.parse()?);
+                    if let Some(msg) = message.take() {
+                        custom_errors[0] = Some(msg);
+                    }
                 } else if ident == "sign" {
                     check_already_used_attr!(sign, ident.span());
                     inner.parse::<syn::Token![:]>()?;
                     sign = Some(inner.parse()?);
-                } else if ident == "type" {
+                    if let Some(msg) = message.take() {
+                        custom_errors[1] = Some(msg);
+                    }
+                } else if ident == "ftype" {
                     check_already_used_attr!(r#type, ident.span());
                     inner.parse::<syn::Token![:]>()?;
                     r#type = Some(inner.parse()?);
+                    if let Some(msg) = message.take() {
+                        custom_errors[2] = Some(msg);
+                    }
                 } else {
                     abort!(
                         ident.span(),
@@ -158,6 +237,10 @@ impl Parse for RodFloatContent {
                     );
                 }
                 _ = inner.parse::<syn::Token![,]>();
+            } else if lookahead.peek(syn::Token![?]) {
+                let _q: syn::Token![?] = inner.parse()?;
+                let result: LitStr = inner.parse()?;
+                message = Some(result);
             } else {
                 abort!(
                     inner.span(),
@@ -169,6 +252,7 @@ impl Parse for RodFloatContent {
             size,
             sign,
             r#type,
+            custom_errors,
         })
     }
 }

--- a/rod_derive/src/types/option.rs
+++ b/rod_derive/src/types/option.rs
@@ -1,15 +1,23 @@
-use syn::{parse::Parse, Ident};
+use proc_macro_error::abort;
+use syn::{parse::Parse, Ident, LitStr};
 use quote::{format_ident, quote};
 
 use crate::{RodAttr, RodAttrContent};
 
-use super::optional_braced;
+use super::{optional_braced, user_defined_error};
 
 macro_rules! rod_content_match {
     ($content:expr, $field_access:expr, $wrap_return:expr, [ $( $variant:ident ),* ]) => {
         match $content {
             $(
                 RodAttrContent::$variant(content) => content.get_validations($field_access, $wrap_return),
+            )*
+        }
+    };
+    ($content:expr, $field_access:expr, $wrap_return:expr, $custom_error:expr, [ $( $variant:ident ),* ]) => {
+        match $content {
+            $(
+                RodAttrContent::$variant(content) => content.get_validations_with_custom_error($field_access, $wrap_return, $custom_error),
             )*
         }
     };
@@ -46,7 +54,8 @@ macro_rules! rod_content_match {
 /// assert!(entity.validate().is_ok());
 /// ```
 pub struct RodOptionContent {
-    pub(crate) inner: Option<Box<RodAttr>>
+    pub(crate) inner: Option<Box<RodAttr>>,
+    custom_none_error: Option<LitStr>,
 }
 
 impl Parse for RodOptionContent {
@@ -55,15 +64,31 @@ impl Parse for RodOptionContent {
         let inner = match opt {
             Some(inner) => inner,
             None => {
-                return Ok(RodOptionContent { inner: None });
+                return Ok(RodOptionContent { inner: None, custom_none_error: None });
             }
         };
         if inner.is_empty() {
-            Ok(RodOptionContent { inner: None })
+            Ok(RodOptionContent { inner: None, custom_none_error: None })
         } else {
-            let inside_opt = inner.parse::<RodAttr>()?;
+            let mut rod_attr: Option<RodAttr> = None;
+            let mut message: Option<LitStr> = None;
+            while !inner.is_empty() {
+                let lookahead = inner.lookahead1();
+                if lookahead.peek(syn::Token![?]) {
+                    let _q: syn::Token![?] = inner.parse()?;
+                    let msg: LitStr = inner.parse()?;
+                    message = Some(msg);
+                } else {
+                    if rod_attr.is_some() {
+                        abort!(inner.span(), "Option attribute can only contain a single inner validation");
+                    }
+                    rod_attr = Some(inner.parse()?);
+                }
+                _ = inner.parse::<syn::Token![,]>();
+            }
             Ok(RodOptionContent {
-                inner: Some(Box::new(inside_opt))
+                inner: rod_attr.map(Box::new),
+                custom_none_error: message,
             })
         }
     }
@@ -73,12 +98,16 @@ impl RodOptionContent {
     pub(crate) fn get_validations(&self, field_name: &Ident, wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         let path = field_name.to_string();
         if self.inner.is_none() {
-            let ret = wrap_return(quote! {
-                RodValidateError::Option(OptionValidation::Some(
-                    #path,
-                    format!("{:?}", #field_name)
-                ))
-            });
+            let ret = if let Some(msg) = self.custom_none_error.as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                wrap_return(quote! {
+                    RodValidateError::Option(OptionValidation::Some(
+                        #path,
+                        format!("{:?}", #field_name)
+                    ))
+                })
+            };
             quote! {
                 if #field_name.is_some() {
                     #ret;
@@ -92,9 +121,50 @@ impl RodOptionContent {
                 [String, Integer, Literal, Boolean, Option, Float, Tuple, Skip, Custom, Iterable]
             );
             let ty = self.inner.as_ref().unwrap().ty.to_string();
-            let ret = wrap_return(quote! {
-                RodValidateError::Option(OptionValidation::None(#path, #ty))
-            });
+            let ret = if let Some(msg) = self.custom_none_error.as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                wrap_return(quote! {
+                    RodValidateError::Option(OptionValidation::None(#path, #ty))
+                })
+            };
+            quote! {
+                match &#field_name {
+                    Some(opt) => {
+                        #inner_validation
+                    }
+                    None => {
+                        #ret;
+                    }
+                }
+            }
+        }
+    }
+    pub(crate) fn get_validations_with_custom_error(&self, field_name: &Ident, wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream, custom_error: &LitStr) -> proc_macro2::TokenStream {
+        if self.inner.is_none() {
+            let ret = if let Some(msg) = self.custom_none_error.as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                user_defined_error(wrap_return, custom_error)
+            };
+            quote! {
+                if #field_name.is_some() {
+                    #ret;
+                }
+            }
+        } else {
+            let inner_validation = rod_content_match!(
+                &self.inner.as_ref().unwrap().content,
+                &format_ident!("opt"),
+                wrap_return,
+                custom_error,
+                [String, Integer, Literal, Boolean, Option, Float, Tuple, Skip, Custom, Iterable]
+            );
+            let ret = if let Some(msg) = self.custom_none_error.as_ref() {
+                user_defined_error(wrap_return, msg)
+            } else {
+                user_defined_error(wrap_return, custom_error)
+            };
             quote! {
                 match &#field_name {
                     Some(opt) => {

--- a/rod_derive/src/types/skip.rs
+++ b/rod_derive/src/types/skip.rs
@@ -1,5 +1,5 @@
 use proc_macro_error::abort;
-use syn::parse::Parse;
+use syn::{parse::Parse, LitStr};
 use quote::quote;
 
 use super::optional_braced;
@@ -45,6 +45,9 @@ impl Parse for RodSkipContent {
 
 impl RodSkipContent {
     pub(crate) fn get_validations(&self, _field_name: &syn::Ident, _wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+        quote! {}
+    }
+    pub(crate) fn get_validations_with_custom_error(&self, _field_name: &syn::Ident, _wrap_return: fn(proc_macro2::TokenStream) -> proc_macro2::TokenStream, _custom_error: &LitStr) -> proc_macro2::TokenStream {
         quote! {}
     }
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -21,6 +21,7 @@ macro_rules! rod_validation_types {
                 $tuple_name($mod_name::$type_name),
             )*
             CheckFailed(&'static str),
+            UserDefined(String),
         }
 
         impl Error for RodValidateError {}
@@ -34,6 +35,8 @@ macro_rules! rod_validation_types {
                     )*
                     RodValidateError::CheckFailed(path) => 
                         write!(f, "Custom validation check failed for `{}`", path),
+                    RodValidateError::UserDefined(msg) => 
+                        write!(f, "{}", msg),
                 }
             }
         }
@@ -62,6 +65,9 @@ macro_rules! rod_validation_types {
             pub fn len(&self) -> usize {
                 self.0.len()
             }
+            pub fn iter(&self) -> std::slice::Iter<'_, RodValidateError> {
+                self.0.iter()
+            }
         }
 
         impl Index<usize> for RodValidateErrorList {
@@ -79,6 +85,8 @@ macro_rules! rod_validation_types {
                 self.0.pop()
             }
         }
+
+
 
         impl Error for RodValidateErrorList {}
 


### PR DESCRIPTION
## Summary
- add per-rule custom error support across derive handlers and runtime
- extend per-validation message coverage in tests
- document the feature and bump crate versions

## Testing
- cargo test
